### PR TITLE
Added binlog capture to GitHub workflow and Azure pipeline

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,13 +48,31 @@ jobs:
         run: dotnet restore src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj
 
       - name: Build MAUI Android
-        run: dotnet publish src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f net9.0-android --no-restore
+        continue-on-error: true # Continue job even if this step fails to capture binlogs.
+        id: build_android
+        run: dotnet publish src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f net9.0-android --no-restore -bl:android-log.binlog
 
+      # Only try and upload build artifacts if the build step succeeded.
       - name: Upload Android Artifact
+        if: steps.build_android.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: mauidotnetpublishbug-android-ci-build
-          path: src/MauiDotnetPublishBug.App/bin/Release/net9.0-android/*Signed.a*
+          name: android-build-artifacts
+          path: |
+            **/*.aab
+            **/*.apk
+
+      # Always upload binlogs if the build step ran.
+      #
+      # Check conclusion here as build_android.continue-on-error = true, so the
+      # conclusion will be 'success' even if the build failed.
+      - name: Upload Android Binlogs
+        if: steps.build_android.conclusion == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-binlogs
+          path: |
+            **/*.binlog
 
   build-ios:
     # macos-15-large would technically be the equivalent to a MS-hosted macos-15
@@ -89,10 +107,28 @@ jobs:
       # repo. Instead, I've tried to use dotnet build to see if it exhibits the
       # same behaviour.
       - name: Build MAUI iOS
-        run: dotnet build src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f net9.0-ios --no-restore /p:buildForSimulator=True /p:packageApp=True /p:ArchiveOnBuild=False
+        id: build_ios
+        continue-on-error: true # Continue job even if this step fails to capture binlogs.
+        run: dotnet build src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f net9.0-ios --no-restore /p:buildForSimulator=True /p:packageApp=True /p:ArchiveOnBuild=False -bl:ios-log.binlog
 
+      # Only try and upload build artifacts if the build step succeeded.
       - name: Upload iOS Artifact
+        if: steps.build_ios.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: mauidotnetpublishbug-ios-ci-build
-          path: src/MauiDotnetPublishBug.App/bin/Release/net9.0-ios/iossimulator-x64/**/*.ipa
+          name: ios-build-artifacts
+          path: |
+            **/*.app
+            **/*.ipa
+
+      # Always upload binlogs if the build step ran.
+      #
+      # Check conclusion here as build_ios.continue-on-error = true, so the
+      # conclusion will be 'success' even if the build failed.
+      - name: Upload iOS Binlogs
+        if: steps.build_ios.conclusion == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-binlogs
+          path: |
+            **/*.binlog

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,6 +41,35 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: UpdateProjectInfo
+        shell: pwsh
+        run: |
+          # Load the System.Xml.Linq assembly to parse the .csproj file.
+          Add-Type -AssemblyName "System.Xml.Linq"
+
+          # Resolve the absolute path to the app .csproj file.
+          $path = (Resolve-Path ".\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj").Path
+
+          # Load the .csproj file as an XDocument.
+          $doc = [System.Xml.Linq.XDocument]::Load($path)
+
+          # Update the ApplicationVersion element to the current build number.
+          $doc.
+              Element("Project").
+              Element("PropertyGroup").
+              Element("ApplicationVersion").
+              SetValue("${{ github.run_attempt }}")
+
+          # Create some XmlWriterSettings to prevent trashing the format of the .csproj file.
+          $settings = New-Object System.Xml.XmlWriterSettings
+          $settings.OmitXmlDeclaration = $true
+          $settings.Indent = $true
+
+          # Save the .csproj with the updated build number.
+          $writer = [System.Xml.XmlWriter]::Create($path, $settings)
+          $doc.Save($writer)
+          $writer.Close()
+
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources
 
@@ -95,6 +124,35 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: UpdateProjectInfo
+        shell: pwsh
+        run: |
+          # Load the System.Xml.Linq assembly to parse the .csproj file.
+          Add-Type -AssemblyName "System.Xml.Linq"
+
+          # Resolve the absolute path to the app .csproj file.
+          $path = (Resolve-Path ".\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj").Path
+
+          # Load the .csproj file as an XDocument.
+          $doc = [System.Xml.Linq.XDocument]::Load($path)
+
+          # Update the ApplicationVersion element to the current build number.
+          $doc.
+              Element("Project").
+              Element("PropertyGroup").
+              Element("ApplicationVersion").
+              SetValue("${{ github.run_attempt }}")
+
+          # Create some XmlWriterSettings to prevent trashing the format of the .csproj file.
+          $settings = New-Object System.Xml.XmlWriterSettings
+          $settings.OmitXmlDeclaration = $true
+          $settings.Indent = $true
+
+          # Save the .csproj with the updated build number.
+          $writer = [System.Xml.XmlWriter]::Create($path, $settings)
+          $doc.Save($writer)
+          $writer.Close()
 
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,9 +28,129 @@ env:
 
 # Define jobs for the workflow.
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    name: Workflow Configuration
+
+    outputs:
+      versionNumber: ${{ steps.get_version.outputs.versionNumber }}
+      androidFramework: ${{ steps.get_target_frameworks.outputs.androidFramework }}
+      iosFramework: ${{ steps.get_target_frameworks.outputs.iosFramework }}
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get App Version
+        id: get_version
+        shell: pwsh
+        run: |
+          Write-Host ""
+          Write-Host "Opening MauiDotnetPublishBug.App.csproj..."
+          $string = Get-Content -Path .\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj
+          Write-Host "Querying MauiDotnetPublishBug.App.csproj for version..."
+          $match = Select-String "<ApplicationDisplayVersion>(\d+)\.(\d+)\.(\d+)" -inputobject $string
+
+          Write-Host "Found the following version:"
+          $projectVersionMajor = $match.Matches.groups[1].value
+          $projectVersionMinor = $match.Matches.groups[2].value
+          $projectVersionBuild = $match.Matches.groups[3].value
+          Write-Host "- Major Version:    $projectVersionMajor"
+          Write-Host "- Minor Version:    $projectVersionMinor"
+          Write-Host "- Build Version:    $projectVersionBuild"
+
+          Write-Host ""
+          Write-Host "Finalising version..."
+          $version = $projectVersionMajor + "." + $projectVersionMinor + "." + $projectVersionBuild
+          Write-Host "- Version is: $version"
+          Write-Host ""
+          Write-Host "Saving to output..."
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "versionNumber=$version"
+
+      - name: Get Target Frameworks
+        id: get_target_frameworks
+        shell: pwsh
+        run: |
+          # Load the System.Xml.Linq assembly to parse the .csproj file.
+          Add-Type -AssemblyName "System.Xml.Linq"
+
+          # Resolve the absolute path to the app .csproj file.
+          $path = (Resolve-Path ".\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj").Path
+
+          # Load the .csproj file as an XDocument.
+          $doc = [System.Xml.Linq.XDocument]::Load($path)
+
+          # Get the target frameworks from the .csproj file.
+          $targetFrameworks = $doc.
+              Element("Project").
+              Element("PropertyGroup").
+              Element("TargetFrameworks").
+              Value
+
+          # Try and get the Android and iOS frameworks from the target
+          # frameworks in the .csproj file.
+          if ($targetFrameworks -match "(?<framework>net\d\.\d-android)") {
+              $androidFramework = $Matches["framework"]
+          }
+          else {
+              # Output an error message displaying the available target
+              # frameworks if a matching framework was not found.
+
+              # Convert the list of target frameworks to a bullet point list.
+              $frameworksList = ($targetFrameworks -split ";" | ForEach-Object { "• $_" }) -join "`n"
+
+              # Output an error and display all target frameworks.
+              Write-Error -Message "Unable to identify Android target framework:`n$frameworksList"
+          }
+          if ($targetFrameworks -match "(?<framework>net\d\.\d-ios)") {
+              $iosFramework = $Matches["framework"]
+          }
+          else {
+              # Output an error message displaying the available target
+              # frameworks if a matching framework was not found.
+
+              # Convert the list of target frameworks to a bullet point list.
+              $frameworksList = ($targetFrameworks -split ";" | ForEach-Object { "• $_" }) -join "`n"
+
+              # Output an error and display all target frameworks.
+              Write-Error -Message "Unable to identify iOS target framework:`n$frameworksList"
+          }
+
+          # If the target frameworks were successfully identified, write them
+          # to variables to be used in the build step.
+          if (-not [string]::IsNullOrEmpty($androidFramework) -and -not [string]::IsNullOrEmpty($androidFramework)) {
+            Write-Host ""
+            Write-Host "Saving target frameworks to output..."
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "androidFramework=$androidFramework"
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "iosFramework=$iosFramework"
+          }
+
+      - name: Display Workflow Configuration
+        id: output_config
+        shell: pwsh
+        run: |
+          Write-Host ""
+          Write-Host "Current Workflow Configuration:"
+          Write-Host ""
+          Write-Host "Runner Configuration:"
+          Write-Host "Xcode Version: ${{ env.XCODE_VERSION }}"
+          Write-Host ""
+          Write-Host "Build Configuration:"
+          Write-Host "Selected .NET Version: ${{ env.DOTNET_VERSION }}"
+          Write-Host "Android TargetFramework: ${{ steps.get_target_frameworks.outputs.androidFramework }}"
+          Write-Host "iOS TargetFramework: ${{ steps.get_target_frameworks.outputs.iosFramework }}"
+          Write-Host ""
+          Write-Host "App Configuration:"
+          Write-Host "App Version: ${{ steps.get_version.outputs.versionNumber }}"
+          Write-Host "Build Number: ${{ github.run_attempt }}"
+
   build-android:
-    runs-on: windows-2022
+    runs-on: macos-15
     name: Android Build
+    needs: config # Wait for the workflow configuration to finish.
+    env:
+      androidFramework: ${{needs.config.outputs.androidFramework}}
     steps:
 
       - name: Checkout
@@ -79,7 +199,7 @@ jobs:
       - name: Build MAUI Android
         continue-on-error: true # Continue job even if this step fails to capture binlogs.
         id: build_android
-        run: dotnet publish src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f net9.0-android --no-restore -bl:android-log.binlog
+        run: dotnet publish src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f ${{ env.androidFramework }} --no-restore -bl:android-log.binlog
 
       # Only try and upload build artifacts if the build step succeeded.
       - name: Upload Android Artifact
@@ -110,6 +230,9 @@ jobs:
     # instead...
     runs-on: macos-15
     name: iOS Build
+    needs: config # Wait for the workflow configuration to finish.
+    env:
+      iosFramework: ${{needs.config.outputs.iosFramework}}
     steps:
 
       - name: Checkout
@@ -167,7 +290,7 @@ jobs:
       - name: Build MAUI iOS
         id: build_ios
         continue-on-error: true # Continue job even if this step fails to capture binlogs.
-        run: dotnet build src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f net9.0-ios --no-restore /p:buildForSimulator=True /p:packageApp=True /p:ArchiveOnBuild=False -bl:ios-log.binlog
+        run: dotnet build src/MauiDotnetPublishBug.App/MauiDotnetPublishBug.App.csproj -c Release -f ${{ env.iosFramework }} --no-restore /p:buildForSimulator=True /p:packageApp=True /p:ArchiveOnBuild=False -bl:ios-log.binlog
 
       # Only try and upload build artifacts if the build step succeeded.
       - name: Upload iOS Artifact

--- a/README.md
+++ b/README.md
@@ -60,44 +60,44 @@ larger app, which I will try and describe below.
 Our app is split across multiple projects, in a similar structure to this:
 
 ```text
-  src
- ├─  MauiDotnetPublishBug.App
- │  ├─  Platforms
- │  │  ├─  Android
- │  │  └─  iOS
- │  ├─  Resources
- │  ├─  Views
- │  │  ├─  MainPage.xaml
- │  │  └─ 󰌛 MainPage.xaml.cs
- │  ├─  App.xaml
- │  ├─ 󰌛 App.xaml.cs
- │  ├─  AppShell.xaml
- │  ├─ 󰌛 AppShell.xaml.cs
- │  ├─  MauiDotnetPublishBug.App.csproj
- │  └─ 󰌛 MauiProgram.cs
- ├─  MauiDotnetPublishBug.Common
- │  ├─  Resources
- │  │  └─ 󰌛 IResourceManager.cs
- │  ├─  Settings
- │  │  └─ 󰌛 ISettingsManager.cs
- │  └─  MauiDotnetPublishBug.Common.csproj
- ├─  MauiDotnetPublishBug.Controls
- │  ├─  Converters
- │  │  ├─ 󰌛 ContrastingTextColourConverter.cs
- │  │  └─ 󰌛 InvertedColourConverter.cs
- │  ├─  ColourPreviewCard.xaml
- │  ├─ 󰌛 ColourPreviewCard.xaml.cs
- │  └─  MauiDotnetPublishBug.Controls.csproj
- ├─  MauiDotnetPublishBug.Core
- │  ├─  Settings
- │  │  └─ 󰌛 SettingsManager.cs
- │  └─  MauiDotnetPublishBug.Core.csproj
- ├─  MauiDotnetPublishBug.Resources
- │  ├─  Icons
- │  ├─  Strings
- │  ├─  MauiDotnetPublishBug.Resources.csproj
- │  └─ 󰌛 ResourceManager.cs
- └─  MauiDotnetPublishBug.sln
+ 📁 src
+ ├─ 📁 MauiDotnetPublishBug.App
+ │  ├─ 📁 Platforms
+ │  │  ├─ 📁 Android
+ │  │  └─ 📁 iOS
+ │  ├─ 📁 Resources
+ │  ├─ 📁 Views
+ │  │  ├─ 🗎 MainPage.xaml
+ │  │  └─ 🗎 MainPage.xaml.cs
+ │  ├─ 🗎 App.xaml
+ │  ├─ 🗎 App.xaml.cs
+ │  ├─ 🗎 AppShell.xaml
+ │  ├─ 🗎 AppShell.xaml.cs
+ │  ├─ 🗎 MauiDotnetPublishBug.App.csproj
+ │  └─ 🗎 MauiProgram.cs
+ ├─ 📁 MauiDotnetPublishBug.Common
+ │  ├─ 📁 Resources
+ │  │  └─ 🗎 IResourceManager.cs
+ │  ├─ 📁 Settings
+ │  │  └─ 🗎 ISettingsManager.cs
+ │  └─ 🗎 MauiDotnetPublishBug.Common.csproj
+ ├─ 📁 MauiDotnetPublishBug.Controls
+ │  ├─ 📁 Converters
+ │  │  ├─ 🗎 ContrastingTextColourConverter.cs
+ │  │  └─ 🗎 InvertedColourConverter.cs
+ │  ├─ 🗎 ColourPreviewCard.xaml
+ │  ├─ 🗎 ColourPreviewCard.xaml.cs
+ │  └─ 🗎 MauiDotnetPublishBug.Controls.csproj
+ ├─ 📁 MauiDotnetPublishBug.Core
+ │  ├─ 📁 Settings
+ │  │  └─ 🗎 SettingsManager.cs
+ │  └─ 🗎 MauiDotnetPublishBug.Core.csproj
+ ├─ 📁 MauiDotnetPublishBug.Resources
+ │  ├─ 📁 Icons
+ │  ├─ 📁 Strings
+ │  ├─ 🗎 MauiDotnetPublishBug.Resources.csproj
+ │  └─ 🗎 ResourceManager.cs
+ └─ 🗎 MauiDotnetPublishBug.sln
 ```
 
 **Note: Some items are omitted for brevity.**

--- a/README.md
+++ b/README.md
@@ -1,15 +1,34 @@
 # MauiDotnetPublishBug
 
-A simple app with a GitHub action to reproduce dotnet/maui#29004.
+A simple app with a GitHub action / Azure pipeline to reproduce
+dotnet/maui#29004.
 
-The Action doesn't deploy the build artifacts anywhere, or do anything fancy for
-that matter, since the bug being reproduced occurs during the `dotnet publish`
-step in the action. Any other contents in the action would just add noise.
+The Action and pipeline don't deploy the build artifacts anywhere, or do
+anything fancy for that matter, since the bug being reproduced occurs during the
+`dotnet publish` / `dotnet build` step in the action. Any other contents in the
+action would just add noise.
 
 Because I needed to add multiple projects to reproduce the bug, I've had to add
 some (slightly ridiculous) classes and usage examples to each project. The uses
 of the projects and general codebase structure is
 [explained in more detail below](#codebase-structure).
+
+<!-- omit from toc -->
+## Contents
+
+- [Bug Details](#bug-details)
+- [Workaround](#workaround)
+- [Codebase Structure](#codebase-structure)
+  - [MauiDotnetPublishBug.App](#mauidotnetpublishbugapp)
+  - [MauiDotnetPublishBug.Common](#mauidotnetpublishbugcommon)
+  - [MauiDotnetPublishBug.Controls](#mauidotnetpublishbugcontrols)
+  - [MauiDotnetPublishBug.Core](#mauidotnetpublishbugcore)
+  - [MauiDotnetPublishBug.Resources](#mauidotnetpublishbugresources)
+- [Azure Pipeline File](#azure-pipeline-file)
+  - [Pipeline Variables](#pipeline-variables)
+  - [Secure Files](#secure-files)
+- [Binlogs](#binlogs)
+- [Licenses and Attributions](#licenses-and-attributions)
 
 ## Bug Details
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ of the projects and general codebase structure is
 I first discovered the bug when I had to update a couple of things all at once
 with our app / pipeline:
 
-- macOS runner image: [ 20250331.1080](https://github.com/actions/runner-images/releases/tag/macos-15%2F20250331.1080) -> [20250408.1132](https://github.com/actions/runner-images/releases/tag/macos-15%2F20250408.1132).
+- macOS runner image: [20250331.1080](https://github.com/actions/runner-images/releases/tag/macos-15%2F20250331.1080) -> [20250408.1132](https://github.com/actions/runner-images/releases/tag/macos-15%2F20250408.1132).
   As we use Microsoft-Hosted agents, this is out of our control.
 - .NET MAUI version (`MauiVersion`): `9.0.50` -> `9.0.60`. We needed to do this
   to resolve some bugs in our app.
@@ -40,6 +40,12 @@ project, and help to pin down the issue.
 It may be worth noting that our app contains multiple projects to help
 [structure our codebase](#codebase-structure). I've replicated this here as I
 believe it is relevant.
+
+> [!IMPORTANT]
+> I don't seem to be able to reproduce the bug using GitHub workflows, at least
+> not with the `macos-15` runners anyway. We use `macos-15` runners in our Azure
+> Pipelines, but I believe that is equivalent to a `macos-15-large` runner in a
+> GitHub workflow.
 
 ## Workaround
 
@@ -185,6 +191,13 @@ variables:
   provisioningProfile: 'MyApp.mobileprovision' # Provisioning profile name in secure files.
   appleCertificate: 'MyApp.p12' # Apple signing certificate name in secure files.
 ```
+
+## Binlogs
+
+Both the [GitHub workflow](.github/workflows/ci-build.yml) and
+[azure pipeline](./azure-pipelines.yml) are configured to capture binlogs during
+the `dotnet publish` / `dotnet build` steps. These will then be uploaded with
+the rest of the artifacts.
 
 ## Licenses and Attributions
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -137,7 +137,7 @@ stages:
         command: publish
         publishWebProjects: false
         projects: $(Build.SourcesDirectory)/src/MauiDotnetPublishBug.sln
-        arguments: $(maxProcessOption) -f net9.0-android -c $(buildConfiguration) -p:AndroidPackageFormat=aab -p:AndroidKeyStore=True -p:AndroidSigningKeyStore=$(DownloadKeyStore.secureFilePath) -p:AndroidSigningStorePass=$(android-keystore-password) -p:AndroidSigningKeyAlias=$(android-key-alias) -p:AndroidSigningKeyPass=$(android-keystore-password)
+        arguments: $(maxProcessOption) -f net9.0-android -c $(buildConfiguration) -p:AndroidPackageFormat=aab -p:AndroidKeyStore=True -p:AndroidSigningKeyStore=$(DownloadKeyStore.secureFilePath) -p:AndroidSigningStorePass=$(android-keystore-password) -p:AndroidSigningKeyAlias=$(android-key-alias) -p:AndroidSigningKeyPass=$(android-keystore-password) -bl:android-log.binlog
         zipAfterPublish: false
         modifyOutputPath: false
 
@@ -150,7 +150,18 @@ stages:
         TargetFolder: $(Build.ArtifactStagingDirectory)
         flattenFolders: true
 
+    # Always try and upload .binlog files.
+    - task: CopyFiles@2
+      condition: always()
+      displayName: Upload Binlogs
+      inputs:
+        Contents: |
+          **/*.binlog
+        TargetFolder: $(Build.ArtifactStagingDirectory)
+        flattenFolders: true
+
     - task: PublishBuildArtifacts@1
+      condition: always()
       displayName: Publish Artifacts
       inputs:
         PathtoPublish: $(Build.ArtifactStagingDirectory)
@@ -289,7 +300,7 @@ stages:
         command: publish
         publishWebProjects: false
         projects: $(Build.SourcesDirectory)/src/MauiDotnetPublishBug.sln
-        arguments: $(maxProcessOption) -f net9.0-ios -c $(buildConfiguration) -p:ArchiveOnBuild=true -p:CodesignKey="$(APPLE_CERTIFICATE_SIGNING_IDENTITY)" -p:CodesignProvision="$(APPLE_PROV_PROFILE_UUID)
+        arguments: $(maxProcessOption) -f net9.0-ios -c $(buildConfiguration) -p:ArchiveOnBuild=true -p:CodesignKey="$(APPLE_CERTIFICATE_SIGNING_IDENTITY)" -p:CodesignProvision="$(APPLE_PROV_PROFILE_UUID)" -bl:ios-log.binlog
         zipAfterPublish: false
         modifyOutputPath: false
 
@@ -302,7 +313,18 @@ stages:
         TargetFolder: $(Build.ArtifactStagingDirectory)
         flattenFolders: true
 
+    # Always try and upload .binlog files.
+    - task: CopyFiles@2
+      condition: always()
+      displayName: Upload Binlogs
+      inputs:
+        Contents: |
+          **/*.binlog
+        TargetFolder: $(Build.ArtifactStagingDirectory)
+        flattenFolders: true
+
     - task: PublishBuildArtifacts@1
+      condition: always()
       displayName: Publish Artifacts
       inputs:
         PathtoPublish: $(Build.ArtifactStagingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,38 @@ stages:
         packageType: sdk
         version: $(dotNetVersion)
 
+    - task: PowerShell@2
+      displayName: Update Project Information
+      name: UpdateProjectInfo
+      inputs:
+        targetType: inline
+        script: |
+          # Load the System.Xml.Linq assembly to parse the .csproj file.
+          Add-Type -AssemblyName "System.Xml.Linq"
+
+          # Resolve the absolute path to the app .csproj file.
+          $path = (Resolve-Path ".\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj").Path
+
+          # Load the .csproj file as an XDocument.
+          $doc = [System.Xml.Linq.XDocument]::Load($path)
+
+          # Update the ApplicationVersion element to the current build number.
+          $doc.
+              Element("Project").
+              Element("PropertyGroup").
+              Element("ApplicationVersion").
+              SetValue("$(Build.BuildNumber)")
+
+          # Create some XmlWriterSettings to prevent trashing the format of the .csproj file.
+          $settings = New-Object System.Xml.XmlWriterSettings
+          $settings.OmitXmlDeclaration = $true
+          $settings.Indent = $true
+
+          # Save the .csproj with the updated build number.
+          $writer = [System.Xml.XmlWriter]::Create($path, $settings)
+          $doc.Save($writer)
+          $writer.Close()
+
     - task: Bash@3
       displayName: Install MAUI workloads
       inputs:
@@ -178,6 +210,39 @@ stages:
       inputs:
         packageType: sdk
         version: $(dotNetVersion)
+
+    - task: PowerShell@2
+      displayName: Update Project Information
+      name: UpdateProjectInfo
+      inputs:
+        targetType: inline
+        script: |
+          # Load the System.Xml.Linq assembly to parse the .csproj file.
+          Add-Type -AssemblyName "System.Xml.Linq"
+
+          # Resolve the absolute path to the app .csproj file.
+          $path = (Resolve-Path ".\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj").Path
+
+          # Load the .csproj file as an XDocument.
+          $doc = [System.Xml.Linq.XDocument]::Load($path)
+
+
+          # Update the ApplicationVersion element to the current build number.
+          $doc.
+              Element("Project").
+              Element("PropertyGroup").
+              Element("ApplicationVersion").
+              SetValue("$(Build.BuildNumber)")
+
+          # Create some XmlWriterSettings to prevent trashing the format of the .csproj file.
+          $settings = New-Object System.Xml.XmlWriterSettings
+          $settings.OmitXmlDeclaration = $true
+          $settings.Indent = $true
+
+          # Save the .csproj with the updated build number.
+          $writer = [System.Xml.XmlWriter]::Create($path, $settings)
+          $doc.Save($writer)
+          $writer.Close()
 
     - task: Bash@3
       displayName: Install MAUI workloads

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,101 @@ stages:
       steps:
 
       - task: PowerShell@2
+        displayName: 'Get App Version'
+        name: SetVersion
+        inputs:
+          targetType: 'inline'
+          script: |
+
+            Write-Host ""
+            Write-Host "Opening MauiDotnetPublishBug.App.csproj..."
+            $string = Get-Content -Path .\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj
+            Write-Host "Querying MauiDotnetPublishBug.App.csproj for version..."
+            $match = Select-String "<ApplicationDisplayVersion>(\d+)\.(\d+)\.(\d+)" -inputobject $string
+
+            Write-Host "Found the following version:"
+            $projectVersionMajor = $match.Matches.groups[1].value
+            $projectVersionMinor = $match.Matches.groups[2].value
+            $projectVersionBuild = $match.Matches.groups[3].value
+            Write-Host "- Major Version:    $projectVersionMajor"
+            Write-Host "- Minor Version:    $projectVersionMinor"
+            Write-Host "- Build Version:    $projectVersionBuild"
+
+            Write-Host ""
+            Write-Host "Finalising version..."
+            $version = $projectVersionMajor + "." + $projectVersionMinor + "." + $projectVersionBuild
+            Write-Host "- Version is: $version"
+            Write-Host ""
+            Write-Host "Saving to pipeline variable..."
+            Write-Host "##vso[task.setvariable variable=versionNumber;isOutput=true;]$version"
+
+          failOnStderr: true
+          showWarnings: true
+
+      - task: PowerShell@2
+        displayName: 'Get Target Frameworks'
+        name: GetTargetFrameworks
+        inputs:
+          targetType: 'inline'
+          script: |
+
+            # Load the System.Xml.Linq assembly to parse the .csproj file.
+            Add-Type -AssemblyName "System.Xml.Linq"
+
+            # Resolve the absolute path to the app .csproj file.
+            $path = (Resolve-Path ".\src\MauiDotnetPublishBug.App\MauiDotnetPublishBug.App.csproj").Path
+
+            # Load the .csproj file as an XDocument.
+            $doc = [System.Xml.Linq.XDocument]::Load($path)
+
+            # Get the target frameworks from the .csproj file.
+            $targetFrameworks = $doc.
+                Element("Project").
+                Element("PropertyGroup").
+                Element("TargetFrameworks").
+                Value
+
+            # Try and get the Android and iOS frameworks from the target
+            # frameworks in the .csproj file.
+            if ($targetFrameworks -match "(?<framework>net\d\.\d-android)") {
+                $androidFramework = $Matches["framework"]
+            }
+            else {
+                # Output an error message displaying the available target
+                # frameworks if a matching framework was not found.
+
+                # Convert the list of target frameworks to a bullet point list.
+                $frameworksList = ($targetFrameworks -split ";" | ForEach-Object { "• $_" }) -join "`n"
+
+                # Output an error and display all target frameworks.
+                Write-Error -Message "Unable to identify Android target framework:`n$frameworksList"
+            }
+            if ($targetFrameworks -match "(?<framework>net\d\.\d-ios)") {
+                $iosFramework = $Matches["framework"]
+            }
+            else {
+                # Output an error message displaying the available target
+                # frameworks if a matching framework was not found.
+
+                # Convert the list of target frameworks to a bullet point list.
+                $frameworksList = ($targetFrameworks -split ";" | ForEach-Object { "• $_" }) -join "`n"
+
+                # Output an error and display all target frameworks.
+                Write-Error -Message "Unable to identify iOS target framework:`n$frameworksList"
+            }
+
+            # If the target frameworks were successfully identified, write them
+            # to variables to be used in the build step.
+            if (-not [string]::IsNullOrEmpty($androidFramework) -and -not [string]::IsNullOrEmpty($androidFramework)) {
+              Write-Host ""
+              Write-Host "Saving target frameworks to pipeline variable..."
+              Write-Host "##vso[task.setvariable variable=androidFramework;isOutput=true;]$androidFramework"
+              Write-Host "##vso[task.setvariable variable=iosFramework;isOutput=true;]$iosFramework"
+            }
+          failOnStderr: true
+          showWarnings: true
+
+      - task: PowerShell@2
         displayName: 'Display Pipeline Configuration'
         name: DisplayConfig
         inputs:
@@ -76,13 +171,17 @@ stages:
             Write-Host ""
             Write-Host "Pipeline Build Configuration:"
             Write-Host "Selected .NET Version: $(dotNetVersion)"
+            Write-Host "Android TargetFramework: $(GetTargetFrameworks.androidFramework)"
+            Write-Host "iOS TargetFramework: $(GetTargetFrameworks.iosFramework)"
             Write-Host "Solution Build Configuration: $(buildConfiguration)"
             Write-Host "Max. Concurrent Build Processes: $(maxProcesses)"
             Write-Host "Max. Processes Option: $(maxProcessOption)"
             Write-Host ""
-            Write-Host "Secure File Configuration:"
+            Write-Host "App Configuration:"
+            Write-Host "App Version: $(SetVersion.versionNumber)"
             Write-Host "Android Keystore File: $(keystoreFile)"
             Write-Host "iOS Provisioning Profile: $(provisioningProfile)"
+            Write-Host "iOS .p12 Certificate: $(appleCertificate)"
           failOnStderr: true
           showWarnings: true
 
@@ -97,6 +196,9 @@ stages:
 
   - job: Build_Android
     displayName: Build for Android
+
+    variables:
+      targetFramework: $[ stageDependencies.Prep.Prep.outputs['GetTargetFrameworks.androidFramework'] ]
 
     steps:
 
@@ -169,7 +271,7 @@ stages:
         command: publish
         publishWebProjects: false
         projects: $(Build.SourcesDirectory)/src/MauiDotnetPublishBug.sln
-        arguments: $(maxProcessOption) -f net9.0-android -c $(buildConfiguration) -p:AndroidPackageFormat=aab -p:AndroidKeyStore=True -p:AndroidSigningKeyStore=$(DownloadKeyStore.secureFilePath) -p:AndroidSigningStorePass=$(android-keystore-password) -p:AndroidSigningKeyAlias=$(android-key-alias) -p:AndroidSigningKeyPass=$(android-keystore-password) -bl:android-log.binlog
+        arguments: $(maxProcessOption) -f $(targetFramework) -c $(buildConfiguration) -p:AndroidPackageFormat=aab -p:AndroidKeyStore=True -p:AndroidSigningKeyStore=$(DownloadKeyStore.secureFilePath) -p:AndroidSigningStorePass=$(android-keystore-password) -p:AndroidSigningKeyAlias=$(android-key-alias) -p:AndroidSigningKeyPass=$(android-keystore-password) -bl:android-log.binlog
         zipAfterPublish: false
         modifyOutputPath: false
 
@@ -203,6 +305,9 @@ stages:
   - job: Build_iOS
     displayName: Build for iOS
 
+    variables:
+      targetFramework: $[ stageDependencies.Prep.Prep.outputs['GetTargetFrameworks.iosFramework'] ]
+
     steps:
 
     - task: UseDotNet@2
@@ -225,7 +330,6 @@ stages:
 
           # Load the .csproj file as an XDocument.
           $doc = [System.Xml.Linq.XDocument]::Load($path)
-
 
           # Update the ApplicationVersion element to the current build number.
           $doc.
@@ -357,7 +461,7 @@ stages:
     - task: CmdLine@2
       displayName: 'Set Xcode Version'
       inputs:
-        script: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'$(xcodePath);sudo xcode-select --switch $(xcodePath)/Contents/Developer
+        script: Write-Host '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'$(xcodePath);sudo xcode-select --switch $(xcodePath)/Contents/Developer
 
     - task: DotNetCoreCLI@2
       displayName: Build Project
@@ -365,7 +469,7 @@ stages:
         command: publish
         publishWebProjects: false
         projects: $(Build.SourcesDirectory)/src/MauiDotnetPublishBug.sln
-        arguments: $(maxProcessOption) -f net9.0-ios -c $(buildConfiguration) -p:ArchiveOnBuild=true -p:CodesignKey="$(APPLE_CERTIFICATE_SIGNING_IDENTITY)" -p:CodesignProvision="$(APPLE_PROV_PROFILE_UUID)" -bl:ios-log.binlog
+        arguments: $(maxProcessOption) -f $(targetFramework) -c $(buildConfiguration) -p:ArchiveOnBuild=true -p:CodesignKey="$(APPLE_CERTIFICATE_SIGNING_IDENTITY)" -p:CodesignProvision="$(APPLE_PROV_PROFILE_UUID)" -bl:ios-log.binlog
         zipAfterPublish: false
         modifyOutputPath: false
 


### PR DESCRIPTION
In order to try and capture some more information about what is going on when the .sln is build, I've added a binlog output argument to both pipelines, along with uploading the .binlog files as artifacts.